### PR TITLE
Config emailing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore API keys and passwords
+.env

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: ENV['EMAIL_FROM']
   layout 'mailer'
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,15 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+##### ACTION MAILER ####
+# SMTP SendGrid
+ActionMailer::Base.smtp_settings = {
+  :user_name => ENV['SENDGRID_LOGIN'],
+  :password => ENV['SENDGRID_PWD'],
+  :domain => 'poticha-dev.herokuapp.com',
+  :address => 'smtp.sendgrid.net',
+  :port => 587,
+  :authentication => :plain,
+  :enable_starttls_auto => true
+}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,10 +30,28 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local
 
+  ######### ACTION MAILER ########
+
+  # Authorize emailing through Rails
+  config.action_mailer.perform_deliveries = true
+
+  # Set default URL for emailing if no other SMTP in config/environment.rb
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  # Set the SMTP Action Mailer Configuration (use MailDev to visualize emails on localhost:1080)
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'localhost',
+    port:                 1080,
+    domain:               'localhost',
+    authentication:       'plain'}
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
+
+  ######### END ACTION MAILER ########
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -59,6 +77,4 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  config.action_mailer.perform_deliveries = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,11 +64,21 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "the-kitting-project_#{Rails.env}"
 
+  ######### ACTION MAILER ########
+
+  # Authorize emailing through Rails in production
+  config.action_mailer.perform_deliveries = true
+
+  # Set default URL for emailing 
+  config.action_mailer.default_url_options = { :host => 'https://poticha-dev.herokuapp.com/' }
+
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+
+  ######### END ACTION MAILER ########
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Création du fichier .env (et ajout dans le .gitignore)
Configuration de l'Action Mailer dans les environnements suivants :
- development (SMTP localhost)
- production (SMTP SendGrid > cf détails dans fichier environment.rb et fichier .env)
- ajout d'une adresse d'envoi par défaut "poticha@yopmail.com" (cf fichier.env > ENV['EMAIL_FROM']). A voir si on passe sur une adresse gmail si SendGrid ne fonctionne pas avec une adresse yopmail...

A faire @Beygs  : push la clé API SendGrid à Heroku

Next step prévue dans un prochain commit : génération du controller user_mailer et views associées 

NB : pour mieux visualiser les config liées à Action Mailer dans les fichiers development.rb et production.rb, j'ai inséré les lignes correspondantes comme ceci : 

######### ACTION MAILER ########
les lignes de config...
######### END ACTION MAILER ########