### PR TITLE
Ajout du nombre d'articles au lien 'Mon Panier' de la navbar

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -6,7 +6,11 @@
   <div class='navbar__items'>
     <% if user_signed_in? %>
       <%= link_to 'Mon Compte', user_path(current_user), class: 'item' %>
-      <%= link_to 'Mon Panier', cart_path(current_user.cart), class: 'item' %>
+      <% if current_user.cart.items.count > 0 %>
+        <%= link_to "Mon Panier (#{current_user.cart.items.count})", cart_path(current_user.cart), class: 'item' %>
+      <% else %>
+        <%= link_to 'Mon Panier', cart_path(current_user.cart), class: 'item' %>
+      <% end %>
       <%= link_to 'Me déconnecter', destroy_user_session_path, method: :delete, class: 'item' %>
     <% else %>
       <%= link_to 'Me connecter', new_user_session_path, class: 'item' %>


### PR DESCRIPTION
Modification très simple, sur la suggestion de Cédric : 
- Ajout du nombre d'articles au panier dans le lien de la navbar sous la forme "Mon Panier (x)" pour x articles.
- Si le panier est vide, la structure reste la même qu'avant : "Mon Panier"